### PR TITLE
chore(fix): defer ga-script

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -37,7 +37,7 @@
 			});
 		</script>
 
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-LLGJWF9DHW"></script>
+		<script src="https://www.googletagmanager.com/gtag/js?id=G-LLGJWF9DHW" defer></script>
 		<script nonce="%sveltekit.nonce%">
 			window.dataLayer = window.dataLayer || [];
 			function gtag() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
	- Updated Google Tag Manager script loading to improve page load performance by deferring script execution until after document parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->