### PR TITLE
feat: remove discord link from footer

### DIFF
--- a/src/lib/components/ui/Footer.svelte
+++ b/src/lib/components/ui/Footer.svelte
@@ -20,8 +20,7 @@
 			isExternal: false,
 			icon: MailIcon
 		},
-		{ href: 'https://x.com/2077research', text: 'Twitter', isExternal: true, icon: X },
-		{ href: 'https://discord.gg/2077collective', text: 'Discord', isExternal: true, icon: Discord }
+		{ href: 'https://x.com/2077research', text: 'Twitter', isExternal: true, icon: X }
 	];
 </script>
 

--- a/src/lib/components/ui/Footer.svelte
+++ b/src/lib/components/ui/Footer.svelte
@@ -2,7 +2,6 @@
 	import { ArrowUpRightIcon, InboxIcon, MailIcon, type Icon as IconType } from 'lucide-svelte';
 	import X from '$lib/components/ui/icons/X.svelte';
 	import type { Component } from 'svelte';
-	import Discord from './icons/Discord.svelte';
 
 	type Link = {
 		href: string;
@@ -12,7 +11,7 @@
 	};
 	const links: Link[] = [
 		{ href: '/list', text: 'Latest research', isExternal: false },
-		{ href: '/article-review', text: 'Publish your research', isExternal: false },
+		//{ href: '/article-review', text: 'Publish your research', isExternal: false },
 		{ href: 'https://2077.xyz', text: '2077.xyz', isExternal: true },
 		{
 			href: 'mailto:research@2077.xyz',

--- a/src/lib/components/ui/Footer.svelte
+++ b/src/lib/components/ui/Footer.svelte
@@ -16,7 +16,7 @@
 		{ href: 'https://2077.xyz', text: '2077.xyz', isExternal: true },
 		{
 			href: 'mailto:research@2077.xyz',
-			text: 'Contact us',
+			text: 'Contact',
 			isExternal: false,
 			icon: MailIcon
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated footer navigation links, reducing the total from five to four.
	- Renamed "Contact us" to "Contact."
	- Commented out the "Publish your research" link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->