### PR TITLE
fix: spotlight image

### DIFF
--- a/src/lib/components/ui/ArticleSpotlight.svelte
+++ b/src/lib/components/ui/ArticleSpotlight.svelte
@@ -47,7 +47,7 @@
 <style>
 	img {
 	        width: min(66vw, 960px);
-			height: min(calc(66vw * (1028/1929)), 546px);
+			height: min(calc(66vw * (1028/1929)), 810px);
 			content-visibility: auto;
 	    }
 </style>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated image height in the Article Spotlight component, increasing maximum image height from 546px to 810px.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->